### PR TITLE
Feat : DIG-21 Textarea 공통 컴포넌트 제작

### DIFF
--- a/src/components/TextArea/TextArea.style.tsx
+++ b/src/components/TextArea/TextArea.style.tsx
@@ -1,0 +1,45 @@
+import * as COLOR from "../../constants/color";
+import * as FONT from "../../constants/font";
+import styled from "styled-components";
+
+interface TextareaStyleProps {
+  height?: string;
+}
+
+export const TextareaStyle = styled.textarea<TextareaStyleProps>`
+  width: 100%;
+  height: ${(props) => (props.height ? props.height : "auto")};
+  outline: none;
+  border: 1px solid ${COLOR.Gray1};
+  padding: 12px 20px;
+  font-size: ${FONT.M};
+  &:focus {
+    border: 1px solid ${COLOR.Primary};
+  }
+  border-radius: 5px;
+  resize: none;
+`;
+
+export const Label = styled.label`
+  display: block;
+  width: 100%;
+  margin-top: 10px;
+`;
+
+export const TitleWrapper = styled.span`
+  position: relative;
+  display: inline-block;
+  padding-bottom: 12px;
+  padding-left: 8px;
+`;
+
+export const TextareaTitle = styled.span`
+  font-weight: ${FONT.Bold};
+`;
+export const Required = styled.span`
+  position: absolute;
+  top: -5px;
+  right: -10px;
+  font-weight: ${FONT.Bold};
+  color: ${COLOR.Red};
+`;

--- a/src/components/TextArea/TextArea.tsx
+++ b/src/components/TextArea/TextArea.tsx
@@ -1,0 +1,40 @@
+import { forwardRef } from "react";
+import * as S from "./TextArea.style";
+
+interface Props {
+  placeholder: string;
+  height?: string;
+  textareaTitle?: string;
+  defaultValue?: string;
+  required?: boolean;
+}
+
+// placeholder - Textarea의 placeholder를 지정할 수 있습니다
+// height - Textarea의 placeholder를 지정할 수 있습니다
+// inputTitle - Textarea 항목의 제목을 지정할 수 있습니다. 필요 없으면 사용하지 않아도 됩니다.
+// defaultBalue - Textarea 항목의 기본 값을 지정할 수 있습니다
+// required - Textarea의 항목이 필수 항목일 경우 사용합니다. TextareaTitle 옆에 붉은 * 가 표시됩니다.
+// ref - ref 를 이용해 부모 컴포넌트에서 Textarea의 value를 사용할 수 있습니다.
+const TextArea = forwardRef(function TextArea(
+  { placeholder, height, textareaTitle, defaultValue, required = false }: Props,
+  ref: React.ForwardedRef<HTMLTextAreaElement>,
+) {
+  return (
+    <S.Label>
+      {textareaTitle && (
+        <S.TitleWrapper>
+          <S.TextareaTitle>{textareaTitle}</S.TextareaTitle>
+          {required && <S.Required>*</S.Required>}
+        </S.TitleWrapper>
+      )}
+
+      <S.TextareaStyle
+        height={height}
+        placeholder={placeholder}
+        defaultValue={defaultValue}
+        ref={ref}
+      />
+    </S.Label>
+  );
+});
+export default TextArea;


### PR DESCRIPTION

![image](https://github.com/Goorm-OGJG/Da-It-Gym-FE/assets/79975172/3741777e-b53f-4df4-9310-9a665ffb7052)


placeholder - Textarea의 placeholder를 지정할 수 있습니다
height - Textarea의 placeholder를 지정할 수 있습니다
inputTitle - Textarea 항목의 제목을 지정할 수 있습니다. 필요 없으면 사용하지 않아도 됩니다. defaultBalue - Textarea 항목의 기본 값을 지정할 수 있습니다
required - Textarea의 항목이 필수 항목일 경우 사용합니다. TextareaTitle 옆에 붉은 * 가 표시됩니다. ref - ref 를 이용해 부모 컴포넌트에서 Textarea의 value를 사용할 수 있습니다.