### PR TITLE
Feat : DIG-147 루틴 관련 페이지 UI 수정

### DIFF
--- a/src/api/useRoutineAPI.tsx
+++ b/src/api/useRoutineAPI.tsx
@@ -28,7 +28,7 @@ export interface ScrapRoutinePayload {
 export interface ResponseDetailRoutine {
   writer: string;
   writerImg: string;
-  createdAt: Date;
+  createdAt: string;
   title: string;
   description: string;
   liked: boolean;

--- a/src/api/useRoutineAPI.tsx
+++ b/src/api/useRoutineAPI.tsx
@@ -55,7 +55,7 @@ export interface RoutineInfo {
   title: string;
   likeCounts: number;
   scrapCounts: number;
-  createdAt: Date;
+  createdAt: string;
 }
 
 export interface ResponseExercise {

--- a/src/api/useRoutineAPI.tsx
+++ b/src/api/useRoutineAPI.tsx
@@ -31,6 +31,7 @@ export interface ResponseDetailRoutine {
   createdAt: string;
   title: string;
   description: string;
+  division: number;
   liked: boolean;
   likeCounts: number;
   scraped: boolean;

--- a/src/api/useUserAPI.tsx
+++ b/src/api/useUserAPI.tsx
@@ -4,6 +4,13 @@ import { toast } from "react-toastify";
 import { useSetRecoilState } from "recoil";
 import { UserInfo, userInfoState } from "../recoil/userInfoState";
 
+export interface ResponseSearchUser {
+  userImg: string;
+  nickname: string;
+  info: string;
+  inbodyScore: number;
+}
+
 export function useUserAPI() {
   const axios = useAxios();
   const API_URL = import.meta.env.VITE_API_URL;
@@ -108,11 +115,25 @@ export function useUserAPI() {
       .catch((error) => toast.error(error.message));
   };
 
+  // 유저 검색
+  const requestSearchUser = async (
+    nickname: string,
+    page: number,
+  ): Promise<ResponseSearchUser> => {
+    const size = 10;
+    const response = await axios
+      .get(`${API_URL}/api/users/search?nickname=${nickname}&page=${page}&size=${size}`)
+      .then((response) => response.data.data)
+      .catch((error) => toast.error(error.message));
+    return response;
+  };
+
   return {
     requestKaKaoLogin,
     requestLogout,
     requestDeleteKaKaoWithdraw,
     requestPatchNickname,
     requestDuplicatedNickname,
+    requestSearchUser,
   };
 }

--- a/src/components/ExerciseAccordion/ExerciseAccordion.tsx
+++ b/src/components/ExerciseAccordion/ExerciseAccordion.tsx
@@ -9,6 +9,7 @@ import { Action as RoutineAction } from "../../hooks/useRoutine";
 import { Day, Action as DayAction } from "../../hooks/useDay";
 import AddExerciseModal from "./AddExerciseModal";
 import useExerciseDiaryAPI, { AddHistory } from "../../api/useExerciseDiaryAPI";
+import { useLocation } from "react-router";
 // import { useSearchParams } from "react-router-dom";
 
 export interface Props {
@@ -32,7 +33,7 @@ export default function ExerciseAccordion({
 }: Props) {
   // const [searchParams] = useSearchParams();
   // const date = searchParams.get("date");
-
+  const location = useLocation();
   const [isOpenedRestTimerModal, setIsOpenedRestTimerModal] = useState(-1);
   const [isOpendAddExerciseModal, setIsOpenedAddExerciseModal] = useState(false);
   const { requestAddHistory, requestDeleteHistory, requestDeleteExercise } =
@@ -74,14 +75,12 @@ export default function ExerciseAccordion({
     exerciseIndex: number,
     exerciseListId?: number,
   ): void => {
-    console.log(exerciseListId);
-
-    if (exerciseListId) {
+    if (location.pathname === "/diary") {
       const exercise = day!.exercises.filter(
         (exercise) => exercise.id === exerciseListId,
       );
       const payload: AddHistory = {
-        id: exerciseListId,
+        id: exerciseListId as number,
         setNum: (exercise[0].exerciseSets.length + 1) as number,
         weights: 10,
         counts: 10,

--- a/src/components/FeedInteractionInfo/FeedInteractionInfo.style.tsx
+++ b/src/components/FeedInteractionInfo/FeedInteractionInfo.style.tsx
@@ -16,5 +16,8 @@ export const IconDiv = styled.div`
 `;
 export const LikeCnt = styled.div`
   margin-right: 14px;
+  font-size: ${FONT.S};
 `;
-export const ShareCnt = styled.div``;
+export const ShareCnt = styled.div`
+  font-size: ${FONT.S};
+`;

--- a/src/components/FeedInteractionInfo/FeedInteractionInfo.tsx
+++ b/src/components/FeedInteractionInfo/FeedInteractionInfo.tsx
@@ -12,11 +12,11 @@ function FeedInteractionInfo({ likeCnt, shareCnt }: FeedInteractionInfoProps) {
     <div>
       <S.CntBox>
         <S.IconDiv>
-          <Icon.HeartFill size="24" color={COLOR.Red} />
+          <Icon.Heart size="16" color={COLOR.Red} />
         </S.IconDiv>
         <S.LikeCnt>{likeCnt}</S.LikeCnt>
         <S.IconDiv>
-          <Icon.Share size="24" color={COLOR.Primary} />
+          <Icon.Share size="16" color={COLOR.Primary} />
         </S.IconDiv>
         <S.ShareCnt>{shareCnt}</S.ShareCnt>
       </S.CntBox>

--- a/src/components/RoutineAccordion/RoutineAccordion.tsx
+++ b/src/components/RoutineAccordion/RoutineAccordion.tsx
@@ -62,8 +62,12 @@ export default function RoutineAccordion({
                     handleDayForWriteMyDiary(day);
                   }}
                 >
-                  <Icon.AddCircle size={FONT.M} color={COLOR.Gray2} />
-                  <S.UseFunctionText>내 운동일지로 작성하기</S.UseFunctionText>
+                  {type === "recorded" && (
+                    <>
+                      <Icon.AddCircle size={FONT.M} color={COLOR.Gray2} />
+                      <S.UseFunctionText>내 운동일지로 작성하기</S.UseFunctionText>
+                    </>
+                  )}
                 </S.UseDayWrapper>
               </S.UserInterectionWrapper>
             </S.RoutineHeader>

--- a/src/components/RoutineUser/RoutineUser.tsx
+++ b/src/components/RoutineUser/RoutineUser.tsx
@@ -5,6 +5,7 @@ import HashTagButton from "../HashtagButton/HashtagButton";
 import { HashTagButtonProps } from "../HashtagButton/HashtagButton";
 import useCounts from "../../hooks/useCounts";
 import { useNavigate } from "react-router";
+import { useTimeCalculate } from "../../api/useTimeCalculate";
 interface Props extends HashTagButtonProps {
   routineId: number;
   src: string;
@@ -25,10 +26,11 @@ function RoutineUser({
   timeAgo,
   label,
 }: Props) {
-  const infomation = info.slice(0, Math.min(130, info.length)).concat("...");
+  const infomation = info.slice(0, Math.min(130, info.length));
   const reduceCount = useCounts();
 
   const navigate = useNavigate();
+  const timeCalculator = useTimeCalculate();
 
   return (
     <S.RoutineUserWrapper
@@ -64,7 +66,7 @@ function RoutineUser({
           <S.RoutineDivide>
             <HashTagButton label={label} type="division" />
           </S.RoutineDivide>
-          <S.RoutineTime>{timeAgo}</S.RoutineTime>
+          <S.RoutineTime>{timeCalculator(timeAgo)}</S.RoutineTime>
         </S.BottomBox>
       </S.RoutineBottom>
     </S.RoutineUserWrapper>

--- a/src/constants/excercise.ts
+++ b/src/constants/excercise.ts
@@ -13,27 +13,6 @@ export interface partLabel {
   type: "part" | "exercise";
 }
 
-// export const getExcercisePartName = (exercisePart: ExercisePart) => {
-//   switch (exercisePart) {
-//     case "chest":
-//       return "가슴";
-//     case "back":
-//       return "등";
-//     case "shoulders":
-//       return "어깨";
-//     case "legs":
-//       return "하체";
-//     case "biceps":
-//       return "이두";
-//     case "triceps":
-//       return "삼두";
-//     case "abs":
-//       return "복근";
-//     case "cardio":
-//       return "유산소";
-//   }
-// };
-
 export const partLabels: partLabel[] = [
   {
     exercisePart: "가슴",
@@ -61,6 +40,10 @@ export const partLabels: partLabel[] = [
   },
   {
     exercisePart: "유산소",
+    type: "part",
+  },
+  {
+    exercisePart: "하체",
     type: "part",
   },
 ];

--- a/src/hooks/useRoutineDetailState.tsx
+++ b/src/hooks/useRoutineDetailState.tsx
@@ -6,6 +6,7 @@ type RoutineDetail = {
   createdAt: string;
   title: string;
   description: string;
+  division: number;
   liked: boolean;
   likeCounts: number;
   scraped: boolean;
@@ -18,6 +19,7 @@ const initialState = {
   createdAt: "",
   title: "제목",
   description: "내용을 불러오는 중 입니다...",
+  division: 1,
   liked: false,
   likeCounts: 0,
   scraped: false,

--- a/src/hooks/useRoutineDetailState.tsx
+++ b/src/hooks/useRoutineDetailState.tsx
@@ -3,7 +3,7 @@ import { useState } from "react";
 type RoutineDetail = {
   writer: string;
   writerImg: string;
-  createdAt: Date;
+  createdAt: string;
   title: string;
   description: string;
   liked: boolean;
@@ -15,7 +15,7 @@ type RoutineDetail = {
 const initialState = {
   writer: "작성자",
   writerImg: "/images/start_logo.png",
-  createdAt: new Date(),
+  createdAt: "",
   title: "제목",
   description: "내용을 불러오는 중 입니다...",
   liked: false,

--- a/src/pages/FeedNewRoutine/FeedNewRoutine.style.tsx
+++ b/src/pages/FeedNewRoutine/FeedNewRoutine.style.tsx
@@ -24,7 +24,7 @@ export const WriterProfileImgWrapper = styled.div`
   width: 48px;
   height: 48px;
   border-radius: 10px;
-  background-color: ${COLOR.Gray1};
+  background-color: ${COLOR.White};
   overflow: hidden;
 `;
 

--- a/src/pages/FeedNewRoutine/FeedNewRoutine.style.tsx
+++ b/src/pages/FeedNewRoutine/FeedNewRoutine.style.tsx
@@ -25,9 +25,13 @@ export const WriterProfileImgWrapper = styled.div`
   height: 48px;
   border-radius: 10px;
   background-color: ${COLOR.Gray1};
+  overflow: hidden;
 `;
 
-export const WriterProfileImg = styled.img``;
+export const WriterProfileImg = styled.img`
+  width: inherit;
+  height: inherit;
+`;
 
 export const Select = styled.select`
   padding: 2px 10px;

--- a/src/pages/FeedNewRoutine/FeedNewRoutine.tsx
+++ b/src/pages/FeedNewRoutine/FeedNewRoutine.tsx
@@ -9,10 +9,12 @@ import Input from "../../components/Input/Input";
 import Button from "../../components/Button/Button";
 import TextArea from "../../components/TextArea/TextArea";
 import * as S from "./FeedNewRoutine.style";
-import { useLocation } from "react-router";
+import { useLocation, useNavigate } from "react-router";
+import { toast } from "react-toastify";
 
 function FeedNewRoutine() {
   const location = useLocation();
+  const navigate = useNavigate();
   const user = useRecoilValue(userInfoState);
   const [routine, dispatch] = useRoutine();
   const [selectedDivision, setSelectedDivision] = useState<number>(1);
@@ -32,6 +34,8 @@ function FeedNewRoutine() {
       routine: routine,
     };
     requestCreateRoutine(payload);
+    toast.success("루틴을 등록했습니다.");
+    navigate("/feed/routine");
   };
 
   useEffect(() => {

--- a/src/pages/FeedNewRoutine/FeedNewRoutine.tsx
+++ b/src/pages/FeedNewRoutine/FeedNewRoutine.tsx
@@ -40,6 +40,8 @@ function FeedNewRoutine() {
 
   useEffect(() => {
     const friendRoutine: Routine = location.state?.routine;
+    const friendRoutineDivision = location.state?.division;
+    friendRoutineDivision && setSelectedDivision(location.state?.division);
     friendRoutine && dispatch({ type: "UPDATE_ROUTINE", newRoutine: friendRoutine });
   }, []);
 

--- a/src/pages/FeedRoutine/FeedRoutine.style.tsx
+++ b/src/pages/FeedRoutine/FeedRoutine.style.tsx
@@ -42,6 +42,7 @@ export const Tab = styled.div<TabProps>`
   justify-content: center;
   height: 60px;
   flex: 1;
+  color: ${({ isSelected }) => (isSelected ? COLOR.Primary : COLOR.Gray2)};
   border-top: 1px solid ${COLOR.Gray1};
   border-top-color: ${({ isSelected }) => (isSelected ? COLOR.Primary : "transparent")};
   border-right: 1px solid ${COLOR.Gray1};

--- a/src/pages/FeedRoutine/FeedRoutine.style.tsx
+++ b/src/pages/FeedRoutine/FeedRoutine.style.tsx
@@ -69,3 +69,8 @@ export const Routines = styled.div`
     display: none;
   }
 `;
+
+export const EmptySpan = styled.span`
+  display: flex;
+  text-align: center;
+`;

--- a/src/pages/FeedRoutine/FeedRoutine.tsx
+++ b/src/pages/FeedRoutine/FeedRoutine.tsx
@@ -245,12 +245,12 @@ export default function FeedRoutine() {
           <RoutineUser
             key={routine.id}
             routineId={routine.id}
-            src={routine.userImg}
+            src={routine.authorImg}
             userName={routine.author}
             info={routine.title}
             likeCount={routine.likeCounts}
             shareCount={routine.scrapCounts}
-            timeAgo={new Date(routine.createdAt).toLocaleString()}
+            timeAgo={routine.createdAt}
             label={selectedDivision}
           />
         ))}

--- a/src/pages/FeedRoutine/FeedRoutine.tsx
+++ b/src/pages/FeedRoutine/FeedRoutine.tsx
@@ -4,6 +4,7 @@ import Nav from "../../components/Nav/Nav";
 import RoutineUser from "../../components/RoutineUser/RoutineUser";
 import * as S from "./FeedRoutine.style";
 import useRoutineAPI, { RoutineInfo } from "../../api/useRoutineAPI";
+import FeedDiaryEmpty from "../../components/FeedEmptyDataUI/FeedDiaryEmpty";
 
 // const tempData: RoutineInfo[] = [
 //   {
@@ -241,6 +242,15 @@ export default function FeedRoutine() {
       </S.Header>
 
       <S.Routines ref={routinesRef}>
+        {routines.length === 0 && (
+          <FeedDiaryEmpty>
+            <S.EmptySpan>
+              루틴이 없습니다.
+              <br />
+              누구보다 먼저 루틴을 만들어보세요!
+            </S.EmptySpan>
+          </FeedDiaryEmpty>
+        )}
         {routines.map((routine) => (
           <RoutineUser
             key={routine.id}

--- a/src/pages/FeedRoutineDetail/FeedRoutineDetail.styled.tsx
+++ b/src/pages/FeedRoutineDetail/FeedRoutineDetail.styled.tsx
@@ -25,6 +25,7 @@ export const WriterProfileImgWrapper = styled.div`
   height: 48px;
   border-radius: 10px;
   background-color: ${COLOR.White};
+  cursor: pointer;
 `;
 
 export const WriterProfileImg = styled.img`
@@ -59,7 +60,9 @@ export const BoardWritedTime = styled.span`
   color: ${COLOR.Gray2};
 `;
 
-export const BoardDescriptionWrapper = styled.div``; // 고민 중
+export const BoardDescriptionWrapper = styled.div`
+  margin-bottom: 40px;
+`;
 
 export const Description = styled.p`
   padding: 2px 0;

--- a/src/pages/FeedRoutineDetail/FeedRoutineDetail.tsx
+++ b/src/pages/FeedRoutineDetail/FeedRoutineDetail.tsx
@@ -12,9 +12,11 @@ import { useNavigate, useParams } from "react-router";
 import useRoutineDetailState from "../../hooks/useRoutineDetailState";
 import { useRecoilValue } from "recoil";
 import { userInfoState } from "../../recoil/userInfoState";
+import { useTimeCalculate } from "../../api/useTimeCalculate";
 
 export default function FeedRoutineDetail() {
   const navigate = useNavigate();
+  const timeCalculator = useTimeCalculate();
   const { routineId } = useParams();
   const [routine, dispatch] = useRoutine();
   const {
@@ -130,7 +132,7 @@ export default function FeedRoutineDetail() {
         <S.BoardTitleWrapper>
           <S.BoardTitle>{routineDetailState.title}</S.BoardTitle>
           <S.BoardWritedTime>
-            {new Date(routineDetailState.createdAt).toLocaleString()}
+            {timeCalculator(routineDetailState.createdAt)}
           </S.BoardWritedTime>
         </S.BoardTitleWrapper>
 

--- a/src/pages/FeedRoutineDetail/FeedRoutineDetail.tsx
+++ b/src/pages/FeedRoutineDetail/FeedRoutineDetail.tsx
@@ -36,6 +36,10 @@ export default function FeedRoutineDetail() {
   const user = useRecoilValue(userInfoState);
   const isMyFeed = user.nickname === routineDetailState.writer;
 
+  const handleClickProfileImg = (nickname: string) => {
+    navigate(`/profile/${nickname}?section=routines`);
+  };
+
   const handleToggleLike = async (liked: boolean) => {
     const newLikeCounts = liked
       ? await requestDislike(routineId as string)
@@ -57,15 +61,16 @@ export default function FeedRoutineDetail() {
   const handleUpdateRoutine = async (routineId: number) => {
     const response = await requestDetailRoutine(routineId);
     const { routine, ...routineDetail } = response;
-
+    console.log(response);
     dispatch({ type: "UPDATE_ROUTINE", newRoutine: routine });
     setRoutineDetailState(routineDetail);
   };
 
-  const handleWriteMyRoutine = (routine: Routine) => {
+  const handleWriteMyRoutine = (routine: Routine, division: number) => {
     navigate(`/feed/routine/new`, {
       state: {
         routine,
+        division,
       },
     });
   };
@@ -85,7 +90,11 @@ export default function FeedRoutineDetail() {
       <S.BoardContainer>
         <S.BoardHeader>
           <S.WriterInfoWrapper>
-            <S.WriterProfileImgWrapper>
+            <S.WriterProfileImgWrapper
+              onClick={() => {
+                handleClickProfileImg(routineDetailState.writer);
+              }}
+            >
               <S.WriterProfileImg src={routineDetailState.writerImg} alt="img" />
             </S.WriterProfileImgWrapper>
             <S.BoardTitle>{routineDetailState.writer}</S.BoardTitle>
@@ -152,7 +161,7 @@ export default function FeedRoutineDetail() {
 
           <S.UserInterectionWrapper
             onClick={() => {
-              handleWriteMyRoutine(routine);
+              handleWriteMyRoutine(routine, routineDetailState.division);
             }}
           >
             <Icon.AddCircle size={FONT.M} color={COLOR.Gray2} />


### PR DESCRIPTION
## 작업 목록
비활성화 탭 글자 색상 변경
루틴 작성 일자 UI 변경: ~일전
운동 추가에서 하체 탭 추가
루틴 작성 페이지에서 "내 운동일지로 작성하기" 제거
작성일 ~일 전으로 출력되게 수정
루틴 작성 후 루틴 목록 페이지로 리다이렉트
루틴 작성 후 Toast 출력
루틴 목록 페이지 루틴 없을때의 컴포넌트 추가
루틴 가져오기 시 루틴 자동 설정 기능 추가
루틴 상세보기 페이지 좋아요 수, 스크랩 수 UI 개선
루틴 상세보기 페이지 프로필 사진 클릭 시 프로필 페이지로 이동


![image](https://github.com/Goorm-OGJG/Da-It-Gym-FE/assets/79975172/7896703a-1772-4b5a-a574-c125c3df769a)
![image](https://github.com/Goorm-OGJG/Da-It-Gym-FE/assets/79975172/4b3ef69d-1f8a-4b05-bd6a-0c10fa712b68)
![image](https://github.com/Goorm-OGJG/Da-It-Gym-FE/assets/79975172/c7642560-30c6-4c63-850e-7fbd646bfe66)

